### PR TITLE
Add manual control mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ for _ in range(1000):
 env.close()
 ```
 
-The agent moves left, right, or jumps with discrete actions. Reaching the far right side of the screen ends the episode with a reward of `1.0`.
+The agent moves left, right, jumps, or stays idle with discrete actions. Reaching the far right side of the screen ends the episode with a reward of `1.0`.
 
 ## Quick Start
 
@@ -43,5 +43,7 @@ Run the environment with the included script from the repository root. The
 environment is registered automatically when ``gym_terraria`` is imported:
 
 ```bash
-python run_env.py
+python run_env.py              # AI-controlled random actions
+python run_env.py --control manual  # Play manually with the keyboard
 ```
+When playing manually use the arrow keys (or ``A``/``D``) to move and ``Space`` to jump.

--- a/gym_terraria/terraria_env.py
+++ b/gym_terraria/terraria_env.py
@@ -15,7 +15,7 @@ class TerrariaEnv(gym.Env):
         self.screen_height = 480
         self.tile_size = 32
 
-        self.action_space = spaces.Discrete(3)  # 0 left, 1 right, 2 jump
+        self.action_space = spaces.Discrete(4)  # 0 left, 1 right, 2 jump, 3 idle
 
         high = np.array(
             [self.screen_width, self.screen_height, np.finfo(np.float32).max, np.finfo(np.float32).max],
@@ -49,7 +49,7 @@ class TerrariaEnv(gym.Env):
             self.velocity[0] = -self.speed
         elif action == 1:  # right
             self.velocity[0] = self.speed
-        else:
+        else:  # idle or jump
             self.velocity[0] = 0
 
         if action == 2 and self._on_ground():

--- a/run_env.py
+++ b/run_env.py
@@ -1,10 +1,20 @@
 """Simple script to play the Terraria gym environment."""
 
+import argparse
 import pygame
 import gym
 import gym_terraria
 
 def main():
+    parser = argparse.ArgumentParser(description="Run the Terraria gym environment")
+    parser.add_argument(
+        "--control",
+        choices=["ai", "manual"],
+        default="ai",
+        help="Choose control mode: 'ai' uses random actions, 'manual' uses the keyboard",
+    )
+    args = parser.parse_args()
+
     pygame.init()
     env = gym.make("Terraria-v0")
     obs, info = env.reset()
@@ -13,7 +23,20 @@ def main():
         for event in pygame.event.get():
             if event.type == pygame.QUIT:
                 done = True
-        action = env.action_space.sample()
+
+        if args.control == "manual":
+            keys = pygame.key.get_pressed()
+            if keys[pygame.K_LEFT] or keys[pygame.K_a]:
+                action = 0
+            elif keys[pygame.K_RIGHT] or keys[pygame.K_d]:
+                action = 1
+            elif keys[pygame.K_SPACE] or keys[pygame.K_UP]:
+                action = 2
+            else:
+                action = 3
+        else:
+            action = env.action_space.sample()
+
         obs, reward, done, truncated, info = env.step(action)
         env.render()
     env.close()


### PR DESCRIPTION
## Summary
- support optional manual control in `run_env.py`
- allow idle action in `TerrariaEnv`
- document manual controls in README

## Testing
- `python -m py_compile run_env.py gym_terraria/terraria_env.py`

------
https://chatgpt.com/codex/tasks/task_e_684b2b2a13888329b33fc4725a97f8d9