### PR TITLE
Add grid blocks and inventory

### DIFF
--- a/run_env.py
+++ b/run_env.py
@@ -30,7 +30,9 @@ def main():
             action = np.array([
                 keys[pygame.K_LEFT] or keys[pygame.K_a],   # left
                 keys[pygame.K_RIGHT] or keys[pygame.K_d],  # right
-                keys[pygame.K_SPACE] or keys[pygame.K_UP] or keys[pygame.K_w]  # jump
+                keys[pygame.K_SPACE] or keys[pygame.K_UP] or keys[pygame.K_w],  # jump
+                keys[pygame.K_z],  # place block
+                keys[pygame.K_x],  # destroy block
             ], dtype=np.int8)
         else:
             action = env.action_space.sample()
@@ -42,3 +44,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
## Summary
- allow placing and destroying blocks using a grid-based world
- track simple inventory of dirt blocks
- update manual controller for new actions

## Testing
- `python -m py_compile run_env.py gym_terraria/terraria_env.py`

------
https://chatgpt.com/codex/tasks/task_e_684b3d52d2e883298d175b9c8387a180