### PR TITLE
Open-ended world generation with inventory UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ for _ in range(1000):
 env.close()
 ```
 
-The agent moves left, right, jumps, or stays idle with discrete actions. Reaching the far right side of the screen ends the episode with a reward of `1.0`.
+The agent moves left, right, jumps, or stays idle with discrete actions. The world now generates endlessly to the left and right, with the camera following the player.
+Blocks you mine are added to a simple inventory displayed at the top left of the screen.
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary
- extend Terraria environment to generate world horizontally in both directions
- make camera follow the player horizontally
- display inventory counts on screen
- document new behaviour in README

## Testing
- `python -m py_compile gym_terraria/*.py run_env.py`
- `python - <<'PY'
import gym
import gym_terraria
env = gym.make('Terraria-v0')
obs, info = env.reset()
for _ in range(5):
    obs, reward, done, truncated, info = env.step(env.action_space.sample())
    if done:
        break
env.close()
print('done')
PY` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684b70453198832998dc6b16caf3b04c