### PR TITLE
Add trees and multiple ore types

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ env.close()
 ```
 
 The agent moves left, right, jumps, or stays idle with discrete actions. The world now generates endlessly to the left and right, with the camera following the player.
-Blocks you mine are added to a simple inventory displayed at the top left of the screen.
+Trees can appear on the surface and multiple ore types are buried in the stone layers. Blocks you mine are added to a simple inventory displayed at the top left of the screen.
 
 ## Quick Start
 

--- a/gym_terraria/terraria_env.py
+++ b/gym_terraria/terraria_env.py
@@ -46,7 +46,14 @@ class TerrariaEnv(gym.Env):
         self.camera_y = 0
 
         # Simple inventory for mined blocks
-        self.inventory = {"dirt": 10, "stone": 0, "ore": 0}
+        self.inventory = {
+            "dirt": 10,
+            "stone": 0,
+            "copper": 0,
+            "iron": 0,
+            "gold": 0,
+            "wood": 0,
+        }
 
         # Font for UI rendering
         self.font = None
@@ -59,7 +66,14 @@ class TerrariaEnv(gym.Env):
         self.player.x = 50
         self.player.y = self.screen_height - self.tile_size * 2
         self.velocity = [0.0, 0.0]
-        self.inventory = {"dirt": 10, "stone": 0, "ore": 0}
+        self.inventory = {
+            "dirt": 10,
+            "stone": 0,
+            "copper": 0,
+            "iron": 0,
+            "gold": 0,
+            "wood": 0,
+        }
         self.facing = [1, 0]
         return self._get_obs(), {}
 
@@ -144,8 +158,14 @@ class TerrariaEnv(gym.Env):
                     self.inventory["dirt"] += 1
                 elif block == world.STONE:
                     self.inventory["stone"] += 1
-                elif block == world.ORE:
-                    self.inventory["ore"] += 1
+                elif block == world.COPPER_ORE:
+                    self.inventory["copper"] += 1
+                elif block == world.IRON_ORE:
+                    self.inventory["iron"] += 1
+                elif block == world.GOLD_ORE:
+                    self.inventory["gold"] += 1
+                elif block == world.WOOD:
+                    self.inventory["wood"] += 1
                 self._update_blocks()
 
         # extend world horizontally when approaching edges

--- a/gym_terraria/world.py
+++ b/gym_terraria/world.py
@@ -4,27 +4,68 @@ import numpy as np
 EMPTY = 0
 DIRT = 1
 STONE = 2
-ORE = 3
+COPPER_ORE = 3
+IRON_ORE = 4
+GOLD_ORE = 5
+WOOD = 6
+LEAVES = 7
+
+ORE_TYPES = [COPPER_ORE, IRON_ORE, GOLD_ORE]
 
 COLOR_MAP = {
     DIRT: (139, 69, 19),
     STONE: (100, 100, 100),
-    ORE: (255, 215, 0),
+    COPPER_ORE: (184, 115, 51),
+    IRON_ORE: (197, 197, 197),
+    GOLD_ORE: (255, 215, 0),
+    WOOD: (160, 82, 45),
+    LEAVES: (34, 139, 34),
 }
 
-def generate_world(width, height, dirt_layers=3, stone_layers=20, ore_chance=0.02):
-    """Generate a simple world grid with dirt, stone and ore layers."""
+def generate_world(
+    width,
+    height,
+    dirt_layers=3,
+    stone_layers=20,
+    ore_chance=0.02,
+    tree_chance=0.05,
+):
+    """Generate a simple world grid with dirt, stone, ore layers and trees."""
     grid = np.zeros((height, width), dtype=np.int8)
+
     for y in range(height):
         if y >= height - stone_layers:
             grid[y, :] = STONE
             for x in range(width):
                 if np.random.random() < ore_chance:
-                    grid[y, x] = ORE
+                    grid[y, x] = np.random.choice(ORE_TYPES)
         elif y >= height - stone_layers - dirt_layers:
             grid[y, :] = DIRT
+
     # add a bedrock layer at the bottom to stand on
     grid[-1, :] = STONE
+
+    # generate trees on the surface
+    surface_y = height - stone_layers - dirt_layers - 1
+    for x in range(width):
+        if (
+            np.random.random() < tree_chance
+            and grid[surface_y, x] == EMPTY
+            and grid[surface_y + 1, x] == DIRT
+        ):
+            trunk_height = np.random.randint(3, 6)
+            for h in range(trunk_height):
+                y_pos = surface_y - h
+                if y_pos >= 0:
+                    grid[y_pos, x] = WOOD
+            top_y = surface_y - trunk_height + 1
+            for dx in (-1, 0, 1):
+                for dy in (-1, 0, 1):
+                    nx = x + dx
+                    ny = top_y + dy
+                    if 0 <= nx < width and 0 <= ny < height and grid[ny, nx] == EMPTY:
+                        grid[ny, nx] = LEAVES
+
     return grid
 
 def blocks_from_grid(grid, tile_size):


### PR DESCRIPTION
## Summary
- implement copper, iron and gold ore blocks
- add tree generation with wood and leaves
- expand inventory and mining logic for new block types
- note new features in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b724a45248329b04827071216a1cd