### PR TITLE
Add hunger and underwater mechanics

### DIFF
--- a/gym_terraria/player.py
+++ b/gym_terraria/player.py
@@ -17,6 +17,10 @@ class Player:
         self.facing = [1, 0]
         self.max_health = 100
         self.health = self.max_health
+        self.max_food = 100
+        self.food = self.max_food
+        self.max_oxygen = 100
+        self.oxygen = self.max_oxygen
         self.inventory: Dict[str, int] = {
             "dirt": 10,
             "stone": 0,
@@ -34,6 +38,8 @@ class Player:
         self.velocity = [0.0, 0.0]
         self.facing = [1, 0]
         self.health = self.max_health
+        self.food = self.max_food
+        self.oxygen = self.max_oxygen
         for key in self.inventory:
             self.inventory[key] = 10 if key == "dirt" else 0
 

--- a/gym_terraria/world.py
+++ b/gym_terraria/world.py
@@ -9,6 +9,7 @@ IRON_ORE = 4
 GOLD_ORE = 5
 WOOD = 6
 LEAVES = 7
+WATER = 8
 
 ORE_TYPES = [COPPER_ORE, IRON_ORE, GOLD_ORE]
 
@@ -20,6 +21,7 @@ COLOR_MAP = {
     GOLD_ORE: (255, 215, 0),
     WOOD: (160, 82, 45),
     LEAVES: (34, 139, 34),
+    WATER: (0, 0, 255),
 }
 
 def generate_world(
@@ -29,6 +31,7 @@ def generate_world(
     stone_layers=20,
     ore_chance=0.02,
     tree_chance=0.05,
+    water_chance=0.1,
 ):
     """Generate a simple world grid with dirt, stone, ore layers and trees."""
     grid = np.zeros((height, width), dtype=np.int8)
@@ -66,6 +69,13 @@ def generate_world(
                     if 0 <= nx < width and 0 <= ny < height and grid[ny, nx] == EMPTY:
                         grid[ny, nx] = LEAVES
 
+    # generate simple water pools on the surface
+    for x in range(width):
+        if np.random.random() < water_chance and grid[surface_y, x] == EMPTY:
+            grid[surface_y, x] = WATER
+            if surface_y + 1 < height and grid[surface_y + 1, x] == EMPTY:
+                grid[surface_y + 1, x] = WATER
+
     return grid
 
 def blocks_from_grid(grid, tile_size):
@@ -73,11 +83,16 @@ def blocks_from_grid(grid, tile_size):
     import pygame
 
     height, width = grid.shape
-    blocks = []
+    solid = []
+    water = []
     for y in range(height):
         for x in range(width):
             block = grid[y, x]
-            if block != EMPTY:
-                rect = pygame.Rect(x * tile_size, y * tile_size, tile_size, tile_size)
-                blocks.append((rect, block))
-    return blocks
+            if block == EMPTY:
+                continue
+            rect = pygame.Rect(x * tile_size, y * tile_size, tile_size, tile_size)
+            if block == WATER:
+                water.append(rect)
+            else:
+                solid.append((rect, block))
+    return solid, water


### PR DESCRIPTION
## Summary
- add food and oxygen statistics to the player
- extend world generation with water tiles
- handle swimming, drowning and hunger in environment
- render water along with food and oxygen bars

## Testing
- `python -m compileall -q .`
- `pip install gym pygame numpy --quiet`
- `python - <<'PY'
import gym, gym_terraria, pygame
pygame.init()
env = gym.make('Terraria-v0')
obs,_ = env.reset()
env.render()
for _ in range(2):
    env.step(env.action_space.sample())
print('ok')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68560f1b2fb08329a07b7bc2bfff98cf