### PR TITLE
Add food consumption with E key

### DIFF
--- a/gym_terraria/player.py
+++ b/gym_terraria/player.py
@@ -31,6 +31,12 @@ class Player:
             "food": 0,
         }
 
+    def eat_food(self) -> None:
+        """Consume one food item to refill the food bar."""
+        if self.inventory.get("food", 0) > 0 and self.food < self.max_food:
+            self.inventory["food"] -= 1
+            self.food = self.max_food
+
     def reset(self, screen_height: int) -> None:
         """Reset player position and state."""
         self.rect.x = 50

--- a/gym_terraria/terraria_env.py
+++ b/gym_terraria/terraria_env.py
@@ -78,6 +78,9 @@ class TerrariaEnv(gym.Env):
 
         keys = pygame.key.get_pressed()
 
+        if keys[pygame.K_e]:
+            self.player.eat_food()
+
         self.in_water = any(self.player.rect.colliderect(r) for r in self.water_blocks)
 
         if (left or right or jump) and self.player.food > 0:


### PR DESCRIPTION
## Summary
- allow Player to eat food from inventory via new `eat_food` method
- consume food when pressing `E` key in the environment

## Testing
- `python -m py_compile gym_terraria/player.py gym_terraria/terraria_env.py`
- `python - <<'EOF'
import gym
import gym_terraria
import os
os.environ['SDL_VIDEODRIVER'] = 'dummy'
import pygame

env = gym.make('Terraria-v0')
obs, info = env.reset()
env.render()
for _ in range(2):
    obs, reward, done, trunc, info = env.step([0,0,0,0,0])
print('step done, food=', env.player.food)
env.close()
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68571084442083299ddccd03380f6cfd