### PR TITLE
Add mining progress indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ env.close()
 
 The agent moves left, right, jumps, or stays idle with discrete actions. The world now generates endlessly to the left and right, with the camera following the player.
 Trees can appear on the surface and multiple ore types are buried in the stone layers. Blocks you mine are added to a simple inventory displayed at the top left of the screen.
+Mining progress is visible thanks to a translucent square that grows from the centre of the targeted block until it breaks.
 Enemies and passive creatures now spawn randomly over time rather than only at the start of the game.
 
 ## Quick Start

--- a/gym_terraria/terraria_env.py
+++ b/gym_terraria/terraria_env.py
@@ -304,6 +304,22 @@ class TerrariaEnv(gym.Env):
                 continue
             water_color = tuple(int(c * light) for c in world.COLOR_MAP[world.WATER])
             pygame.draw.rect(self.screen, water_color, screen_rect)
+
+        # draw mining progress indicator
+        if self._mining_target is not None and self._mining_progress > 0:
+            tx, ty = self._mining_target
+            block = self.grid[ty, tx]
+            info = blocks.BLOCK_STATS.get(block)
+            required = info.mining_time if info else 1
+            ratio = min(1.0, self._mining_progress / required)
+            size = int(self.tile_size * ratio)
+            if size > 0:
+                offset = (self.tile_size - size) // 2
+                sx = tx * self.tile_size - self.camera_x + offset
+                sy = ty * self.tile_size - self.camera_y + offset
+                overlay = pygame.Surface((size, size), pygame.SRCALPHA)
+                overlay.fill((255, 255, 255, 120))
+                self.screen.blit(overlay, (sx, sy))
         player_color = tuple(int(c * light) for c in (255, 0, 0))
         pygame.draw.rect(self.screen, player_color, self.player.rect.move(-self.camera_x, -self.camera_y))
 


### PR DESCRIPTION
## Summary
- show a translucent square overlay as a block is mined
- mention the new mining progress indicator in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685dd75fcb7c83299fbc05dc7958cfdb