### PR TITLE
Improve inventory UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ env.close()
 ```
 
 The agent moves left, right, jumps, or stays idle with discrete actions. The world now generates endlessly to the left and right, with the camera following the player.
-Trees can appear on the surface and multiple ore types are buried in the stone layers. Blocks you mine are added to a simple inventory displayed at the top left of the screen.
+Trees can appear on the surface and multiple ore types are buried in the stone layers. Blocks you mine are added to an inventory. Press ``E`` in manual mode to open the inventory window, shift-click to move items to the hotbar and double-click a hotbar slot to return the item.
 Mining progress is visible thanks to a translucent square that grows from the centre of the targeted block until it breaks.
 Enemies and passive creatures now spawn randomly over time rather than only at the start of the game.
 


### PR DESCRIPTION
## Summary
- replace text inventory with clickable item grid
- allow shift-click to move items from inventory to hotbar
- allow double-clicking hotbar items to return them
- document the new controls

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `SDL_VIDEODRIVER=dummy python run_env.py --control manual`

------
https://chatgpt.com/codex/tasks/task_e_685deb8dc68c8329a4031d1216ebd64a