### PR TITLE
Move inventory logic to dedicated module

### DIFF
--- a/gym_intrinsic/__init__.py
+++ b/gym_intrinsic/__init__.py
@@ -13,7 +13,8 @@ register(
 
 from .intrinsic_env import IntrinsicEnv
 from .player import Player
+from .inventory import Inventory
 from .enemy_mobs import Enemy, Projectile
 from .passive_mobs import PassiveMob
 
-__all__ = ["InstrinsicEnv", "Player", "Enemy", "Projectile", "PassiveMob"]
+__all__ = ["InstrinsicEnv", "Player", "Inventory", "Enemy", "Projectile", "PassiveMob"]

--- a/gym_intrinsic/intrinsic_env.py
+++ b/gym_intrinsic/intrinsic_env.py
@@ -140,7 +140,7 @@ class IntrinsicEnv(gym.Env):
         ]
         for idx, k in enumerate(number_keys):
             if keys[k]:
-                self.player.selected_slot = idx
+                self.player.inventory.selected_slot = idx
 
         self.in_water = any(self.player.rect.colliderect(r) for r in self.water_blocks)
 
@@ -417,14 +417,14 @@ class IntrinsicEnv(gym.Env):
             # hotbar rendering
             hotbar_y = self.screen_height - self.tile_size - 10
             new_hotbar = []
-            for i, item in enumerate(self.player.hotbar):
+            for i, item in enumerate(self.player.inventory.hotbar):
                 x = 10 + i * (self.tile_size + 4)
                 rect = pygame.Rect(x, hotbar_y, self.tile_size, self.tile_size)
                 pygame.draw.rect(self.screen, (200, 200, 200), rect, 0)
-                border = 3 if i == self.player.selected_slot else 1
+                border = 3 if i == self.player.inventory.selected_slot else 1
                 pygame.draw.rect(
                     self.screen,
-                    (255, 255, 0) if i == self.player.selected_slot else (0, 0, 0),
+                    (255, 255, 0) if i == self.player.inventory.selected_slot else (0, 0, 0),
                     rect,
                     border,
                 )
@@ -530,12 +530,7 @@ class IntrinsicEnv(gym.Env):
 
     def _shift_to_hotbar(self, item: str) -> None:
         """Move one item to the first empty hotbar slot."""
-        if self.player.inventory.get(item, 0) <= 0:
-            return
-        for i, slot in enumerate(self.player.hotbar):
-            if slot is None:
-                self.player.hotbar[i] = item
-                return
+        self.player.inventory.shift_to_hotbar(item)
 
     def _handle_ui_events(self, events) -> None:
         """Handle inventory/hotbar mouse actions."""
@@ -553,8 +548,8 @@ class IntrinsicEnv(gym.Env):
                     for idx, rect in enumerate(self._hotbar_rects):
                         if rect.collidepoint(pos):
                             if now - self._last_hotbar_click[idx] < 400:
-                                item = self.player.hotbar[idx]
+                                item = self.player.inventory.hotbar[idx]
                                 if item:
                                     self.player.inventory[item] = self.player.inventory.get(item, 0)
-                                    self.player.hotbar[idx] = None
+                                    self.player.inventory.hotbar[idx] = None
                             self._last_hotbar_click[idx] = now

--- a/gym_intrinsic/inventory.py
+++ b/gym_intrinsic/inventory.py
@@ -1,0 +1,63 @@
+class Inventory:
+    """Manage player inventory and hotbar."""
+
+    def __init__(self):
+        self.reset()
+
+    def reset(self) -> None:
+        self._items = {
+            "dirt": 10,
+            "stone": 0,
+            "copper": 0,
+            "iron": 0,
+            "gold": 0,
+            "wood": 0,
+            "food": 0,
+        }
+        self.hotbar = [
+            "dirt",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ]
+        self.selected_slot = 0
+
+    # dictionary-like access
+    def __getitem__(self, key):
+        return self._items[key]
+
+    def __setitem__(self, key, value):
+        self._items[key] = value
+
+    def get(self, key, default=None):
+        return self._items.get(key, default)
+
+    def items(self):
+        return self._items.items()
+
+    def add(self, item: str, count: int = 1) -> None:
+        self._items[item] = self._items.get(item, 0) + count
+
+    def remove(self, item: str, count: int = 1) -> bool:
+        if self._items.get(item, 0) < count:
+            return False
+        self._items[item] -= count
+        return True
+
+    @property
+    def selected_item(self):
+        return self.hotbar[self.selected_slot]
+
+    def shift_to_hotbar(self, item: str) -> None:
+        if self.get(item, 0) <= 0:
+            return
+        for i, slot in enumerate(self.hotbar):
+            if slot is None:
+                self.hotbar[i] = item
+                return

--- a/gym_intrinsic/player.py
+++ b/gym_intrinsic/player.py
@@ -1,6 +1,6 @@
 import pygame
-from typing import Dict
 from . import world
+from .inventory import Inventory
 
 class Player:
     """Simple player container."""
@@ -21,29 +21,7 @@ class Player:
         self.food = self.max_food
         self.max_oxygen = 100
         self.oxygen = self.max_oxygen
-        self.inventory: Dict[str, int] = {
-            "dirt": 10,
-            "stone": 0,
-            "copper": 0,
-            "iron": 0,
-            "gold": 0,
-            "wood": 0,
-            "food": 0,
-        }
-        # basic 10 slot hotbar with the first slot containing dirt by default
-        self.hotbar = [
-            "dirt",
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-        ]
-        self.selected_slot = 0
+        self.inventory = Inventory()
 
     def eat_food(self) -> None:
         """Consume one food item to refill the food bar."""
@@ -60,21 +38,7 @@ class Player:
         self.health = self.max_health
         self.food = self.max_food
         self.oxygen = self.max_oxygen
-        for key in self.inventory:
-            self.inventory[key] = 10 if key == "dirt" else 0
-        self.hotbar = [
-            "dirt",
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-        ]
-        self.selected_slot = 0
+        self.inventory.reset()
 
     def on_ground(self, grid, grid_height: int, vel_y: float) -> bool:
         """Return True if standing on a solid block."""
@@ -91,4 +55,4 @@ class Player:
     @property
     def selected_item(self):
         """Return the item currently selected in the hotbar."""
-        return self.hotbar[self.selected_slot]
+        return self.inventory.selected_item


### PR DESCRIPTION
## Summary
- create `inventory.py` to encapsulate inventory and hotbar behaviour
- use the new `Inventory` class from `Player`
- update `IntrinsicEnv` to use `Inventory`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
import gym_intrinsic
import os
os.environ['SDL_VIDEODRIVER'] = 'dummy'
env = gym_intrinsic.IntrinsicEnv()
env.render()
obs, info = env.reset()
print('obs0', obs)
obs, reward, done, truncated, info = env.step(env.action_space.sample())
print('obs1', obs)
env.close()
PY`

------
https://chatgpt.com/codex/tasks/task_e_685df04fee04832994137052375f9380