### PR TITLE
Use E key for inventory toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,4 +50,4 @@ python run_env.py              # AI-controlled random actions
 python run_env.py --control manual  # Play manually with the keyboard
 ```
 When playing manually use the arrow keys (or ``A``/``D``) to move and ``Space`` to jump.
-Press number keys ``1``-``0`` to select a hotbar slot for item use.
+Press number keys ``1``-``0`` to select a hotbar slot for item use. Press ``E`` to open or close the inventory and drag items into the hotbar.

--- a/gym_terraria/inventory_ui.py
+++ b/gym_terraria/inventory_ui.py
@@ -16,6 +16,11 @@ class InventoryUI:
         self.offset = (0, 0)
         self.hotbar_rects: List[pygame.Rect] = []
         self.inv_rects: List[Tuple[str, pygame.Rect]] = []
+        self.show_inventory = False
+
+    def toggle(self) -> None:
+        """Toggle inventory visibility."""
+        self.show_inventory = not self.show_inventory
 
     def reposition(self, width: int, height: int) -> None:
         """Compute slot rectangles based on screen size."""
@@ -28,11 +33,12 @@ class InventoryUI:
             self.hotbar_rects.append(rect)
 
         self.inv_rects = []
-        x = 10
-        y = height - self.SLOT_SIZE * (len(self.player.inventory)) - self.SLOT_SIZE - 20
-        for idx, name in enumerate(self.player.inventory.keys()):
-            rect = pygame.Rect(x, y + idx * self.SLOT_SIZE, self.SLOT_SIZE, self.SLOT_SIZE)
-            self.inv_rects.append((name, rect))
+        if self.show_inventory:
+            x = (width - self.SLOT_SIZE) // 2
+            y = height // 2 - (len(self.player.inventory) * self.SLOT_SIZE) // 2
+            for idx, name in enumerate(self.player.inventory.keys()):
+                rect = pygame.Rect(x, y + idx * self.SLOT_SIZE, self.SLOT_SIZE, self.SLOT_SIZE)
+                self.inv_rects.append((name, rect))
 
     def handle_event(self, event) -> None:
         if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
@@ -47,13 +53,14 @@ class InventoryUI:
                         self.offset = (pos[0] - rect.x, pos[1] - rect.y)
                         self.player.hotbar[idx] = None
                     return
-            for idx, (name, rect) in enumerate(self.inv_rects):
-                if rect.collidepoint(pos) and self.player.inventory.get(name, 0) > 0:
-                    self.dragging = name
-                    self.drag_from_hotbar = False
-                    self.drag_index = idx
-                    self.offset = (pos[0] - rect.x, pos[1] - rect.y)
-                    return
+            if self.show_inventory:
+                for idx, (name, rect) in enumerate(self.inv_rects):
+                    if rect.collidepoint(pos) and self.player.inventory.get(name, 0) > 0:
+                        self.dragging = name
+                        self.drag_from_hotbar = False
+                        self.drag_index = idx
+                        self.offset = (pos[0] - rect.x, pos[1] - rect.y)
+                        return
 
         elif event.type == pygame.MOUSEBUTTONUP and event.button == 1:
             pos = event.pos

--- a/gym_terraria/terraria_env.py
+++ b/gym_terraria/terraria_env.py
@@ -104,9 +104,6 @@ class TerrariaEnv(gym.Env):
 
         keys = pygame.key.get_pressed()
 
-        if keys[pygame.K_e]:
-            self.player.eat_food()
-
         self.in_water = any(self.player.rect.colliderect(r) for r in self.water_blocks)
 
         if (left or right or jump) and self.player.food > 0:
@@ -401,6 +398,8 @@ class TerrariaEnv(gym.Env):
                     self.player.selected_slot = event.key - pygame.K_1
                 elif event.key == pygame.K_0:
                     self.player.selected_slot = 9
+                elif event.key == pygame.K_e and self.inventory_ui:
+                    self.inventory_ui.toggle()
             if self.inventory_ui:
                 self.inventory_ui.handle_event(event)
 


### PR DESCRIPTION
## Summary
- hide the side inventory by default
- add `show_inventory` state in `InventoryUI` and `toggle()`
- use `E` key to open/close the inventory
- update README instructions

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8` *(fails: command not found)*
- `python run_env.py --control ai` *(fails: ModuleNotFoundError: No module named 'pygame')*

------
https://chatgpt.com/codex/tasks/task_e_686434501b6c8329bb2c067ad2b7220d